### PR TITLE
Finished 5.1.1.1 Infinite Shell Loop

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,12 +6,20 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:07:08 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/25 12:25:30 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/25 17:51:16 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../libs/libft/libft.h"
 #include "../libs/libft/ft_printf/includes/ft_printf.h"
 
+#define TRUE 1
+#define FALSE 0
+
 //MAIN and LOOP functions
 void	ms_main_loop(void);
+char	*ms_check_empty_input(char *input);
+void	ms_exit_handler(const char *msg);
+
+//ERROR HANDLER functions
+void	ms_error_handler(char *msg);

--- a/src/main/loop.c
+++ b/src/main/loop.c
@@ -6,33 +6,54 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/25 17:03:08 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/25 17:51:06 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+void	ms_exit_handler(const char *msg)
+{
+	if (msg)
+		ft_printf("%s\n", msg);
+	exit(0);
+}
+
+char	*ms_check_empty_input(char *input)
+{
+	char	*trimmed;
+
+	trimmed = ft_strtrim(input, " \n");
+	free(input);
+	if (!trimmed)
+		ms_error_handler("Memory allocation error");
+	if (trimmed[0] == '\0')
+	{
+		free(trimmed);
+		return (NULL);
+	}
+	return (trimmed);
+}
+
 void	ms_main_loop(void)
 {
 	char	*input;
-	char	*trimmed_input;
 
 	while (1)
 	{
 		ft_printf("minishell> ");
 		input = get_next_line(0);
 		if (!input)
-			exit(1);
-		trimmed_input = ft_strtrim(input, " \n");
-		free(input);
-		if (!trimmed_input)
-			exit (1);
-		ft_printf("%s\n", trimmed_input);
-		if (!ft_strncmp(trimmed_input, "exit", 4))
+			ms_exit_handler("exit");
+		input = ms_check_empty_input(input);
+		if (!input)
+			continue ;
+		if (!ft_strncmp(input, "exit", 4))
 		{
-			free(trimmed_input);
-			exit(1);
+			free(input);
+			ms_exit_handler("exit");
 		}
-		free(trimmed_input);
+		ft_printf("%s\n", input);
+		free(input);
 	}
 }

--- a/src/utils/error_handler.c
+++ b/src/utils/error_handler.c
@@ -6,8 +6,15 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/25 11:56:17 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/25 17:27:02 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
+
+void	ms_error_handler(char *msg)
+{
+	if (msg)
+		ft_printf("%s\n", msg);
+	exit(1);
+}


### PR DESCRIPTION
Finished the **basic infinite loop implementation** for Minishell:

-Prints the prompt (I chose minishell> )
-Waits for user input, then cleans it (removes \n and treading/leading whitespace)
-Handles empty input (user just pressess enter)
-Elegantly manages exits (both "exit" and ctrl+d cases) and errors (has an exit function, calls error handler from it's  corresponding file). 
-_Depending on how we need to handle exit points in the future, it might be advisable to have an exit_handler.c in src/utils._
-Checked cases with valgrind and found no memory leaks