### PR TITLE
Finished basic signal handling (mandatory). Fixed loop exit. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,4 @@ Pull request conv, i agreed: we can check the checklists of the project sections
 
 Optional to-do: test dependency implementations
 	-.d files?
-	- libft & printf dependencies on main Makefile (i.e., minishell compilation).
 	-Not die

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,15 +6,19 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:07:08 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/25 17:51:16 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/26 12:33:36 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../libs/libft/libft.h"
-#include "../libs/libft/ft_printf/includes/ft_printf.h"
+#ifndef MINISHELL_H
+# define MINISHELL_H
 
-#define TRUE 1
-#define FALSE 0
+# include "../libs/libft/libft.h"
+# include "../libs/libft/ft_printf/includes/ft_printf.h"
+# include <signal.h>
+
+# define TRUE 1
+# define FALSE 0
 
 //MAIN and LOOP functions
 void	ms_main_loop(void);
@@ -23,3 +27,10 @@ void	ms_exit_handler(const char *msg);
 
 //ERROR HANDLER functions
 void	ms_error_handler(char *msg);
+
+//SIGNAL HANDLER functions
+void	ms_signal_handler(int signal);
+void	ms_sigtstp_handler(void);
+void	ms_sigint_handler(void);
+
+#endif

--- a/src/main/loop.c
+++ b/src/main/loop.c
@@ -6,12 +6,16 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/26 10:18:54 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/26 12:27:04 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Small exit handler that prints an exit msg and exits.
+If needed later on, we can move this to it's own file in utils.
+*/
 void	ms_exit_handler(const char *msg)
 {
 	if (msg)
@@ -19,6 +23,10 @@ void	ms_exit_handler(const char *msg)
 	exit(0);
 }
 
+/*
+Helper function to handle empty user input.
+Trims leading and treading spaces, cleaning the input.
+*/
 char	*ms_check_empty_input(char *input)
 {
 	char	*trimmed;
@@ -35,6 +43,12 @@ char	*ms_check_empty_input(char *input)
 	return (trimmed);
 }
 
+/*
+Main loop for Minishell.
+Prints prompt, waits for input.
+Handles graceful exits and empty input. 
+For now, it just prints back the input.
+*/
 void	ms_main_loop(void)
 {
 	char	*input;
@@ -48,7 +62,7 @@ void	ms_main_loop(void)
 		input = ms_check_empty_input(input);
 		if (!input)
 			continue ;
-		if (!ft_strncmp(input, "exit", 4))
+		if (ft_strlen(input) == 4 && !ft_strncmp(input, "exit", 4))
 		{
 			free(input);
 			ms_exit_handler("exit");

--- a/src/main/minishell.c
+++ b/src/main/minishell.c
@@ -6,13 +6,28 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/25 12:23:20 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/26 12:27:45 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Current main function handles:
+-Setting up the sigaction and signal handler
+-Setting up and initializing the main loop (print prompt, wait for input/signals)
+*/
 int	main(void)
 {
+	struct sigaction	action;
+
+	action.sa_handler = ms_signal_handler;
+	sigemptyset(&action.sa_mask);
+	action.sa_flags = SA_RESTART;
+	if (sigaction(SIGINT, &action, NULL) == -1)
+		ms_error_handler("SIGINT sigaction error");
+	if (sigaction(SIGTSTP, &action, NULL) == -1)
+		ms_error_handler("SIGTSTP sigaction error");
+	sigemptyset(&action.sa_mask);
 	ms_main_loop();
 }

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -6,8 +6,41 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/25 11:56:08 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/26 12:37:18 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
+
+/*
+SIGINT handler.
+It re-prints the prompt in a new line and flushes stdout.
+*/
+
+void	ms_sigint_handler(void)
+{
+	write(STDOUT_FILENO, "\nminishell$ ", 12);
+	fflush(stdout);
+}
+
+/*
+SIGTSTP handler.
+*/
+void	ms_sigtstp_handler(void)
+{
+	write(STDOUT_FILENO, "\nProcess suspended. Type 'fg' to resume.\n", 41);
+	signal(SIGTSTP, SIG_DFL);
+	kill(getpid(), SIGTSTP);
+}
+
+/*
+Signal hub.
+Catches signals and redirects them to their respective handler functions.
+*/
+void	ms_signal_handler(int signal)
+{
+	if (signal == SIGINT)
+		ms_sigint_handler();
+	else if (signal == SIGTSTP)
+		ms_sigtstp_handler();
+}


### PR DESCRIPTION
+ Added handlers for SIGINT (CTRL-C) and SIGTSTP (CTRL-Z), following mandatory requirements (job suspension and handling is BONUS).

+ Fixed loop exit to only catch "exit" string, which was previously triggered by any string starting with "exit", regardless of length or extra following charactes.

+ Removed library dependencies from optional to-dos in README

+ Commented previous and new functions (might have forgotten to comment something; if so, I'd add that in future pushes).