### PR TITLE
simple variable expansion done

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,15 @@ RED 		= \033[0;91m
 
 # -=-=-=-=-    NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= #
 
-NAME 		= minishell
+NAME 		:= minishell
 
-# -=-=-=-=-    PATH -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= #
+# -=-=-=-=-    FLAG -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= #
 
 CC			= cc
 FLAGS		= -Werror -Wall -Wextra -pthread -g -fsanitize=address
 
-# -=-=-=-=-    FILES -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- #
+# -=-=-=-=-    PATH -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- #
+
 LIBFTDIR	= libs/libft/
 PRINTFDIR	= libs/libft/ft_printf/
 RM			= rm -f
@@ -42,9 +43,9 @@ SRCS 		:= 	src/main/minishell.c 		\
 				src/utils/string_utils.c 	\
 				src/utils/error_handler.c 	\
 				src/utils/exit_handler.c	\
-		
+				src/parser/expand_variable.c
 
-OBJS 		= $(SRCS:.c=.o)
+OBJS 		:= $(SRCS:.c=.o)
 
 # -=-=-=-=-    TARGETS -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- #
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:07:08 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/27 18:22:52 by nponchon         ###   ########.fr       */
+/*   Updated: 2024/11/29 00:28:14 by nponchon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,11 +34,16 @@ char	*ms_get_env_variable(t_list *ms_env, const char *var_name);
 char	*ms_check_empty_input(char *input);
 
 //TOKENIZER & SYNTAX CHECK
-void	ms_tokenizer(char *input);
+void	ms_tokenizer(t_list *ms_env, char *str);
 void	ms_syntax_checker(char *str);
-void	ms_checkquotes(char *str, char c);
-void	ms_checkspecialchar(char *str);
-void	ms_checkpipes(char *str);
+int		ms_checkquotes(char *str, char c);
+int		ms_checkspecialchar(char *str);
+int		ms_checkpipes(char *str);
+int		ms_check_empty_pipe(char *str);
+char	*ms_expand_variable(t_list *ms_env, char *str);
+char	*ms_replace_expanded(char *str, char *key, char *var);
+char	*ms_replace_null_value(char *str, char *key);
+char	*ms_search_env(t_list *ms_env, char *str, int start);
 
 //ERROR HANDLER functions
 void	ms_error_handler(char *msg, int is_critical);

--- a/libs/libft/Makefile
+++ b/libs/libft/Makefile
@@ -19,24 +19,18 @@ SRC = ft_itoa.c ft_strchr.c ft_strdup.c ft_strjoin.c ft_strjoin_free.c ft_strmap
       ft_calloc.c ft_memchr.c ft_memcpy.c ft_memmove.c ft_memset.c \
       ft_putchar_fd.c ft_putendl_fd.c ft_putnbr_fd.c ft_putstr_fd.c \
       ft_striteri.c ft_strtrim.c ft_free.c get_next_line.c ft_array_count.c \
-      ft_append_c.c cucufu.c ft_print_array.c
+      ft_append_c.c cucufu.c ft_print_array.c                                 \
+      ft_lstnew_bonus.c ft_lstadd_front_bonus.c ft_lstlast_bonus.c \
+      ft_lstadd_back_bonus.c ft_lstdelone_bonus.c ft_lstclear_bonus.c \
+      ft_lstiter_bonus.c ft_lstmap_bonus.c ft_lstsize_bonus.c
 
 OBJ = $(SRC:.c=.o)
-
-BONUS = ft_lstnew_bonus.c ft_lstadd_front_bonus.c ft_lstlast_bonus.c \
-        ft_lstadd_back_bonus.c ft_lstdelone_bonus.c ft_lstclear_bonus.c \
-        ft_lstiter_bonus.c ft_lstmap_bonus.c ft_lstsize_bonus.c
-
-BONUS_OBJ = $(BONUS:.c=.o)
 
 %.o: %.c libft.h Makefile
 	$(CC) $(FLAGS) -I. -c $< -o $@
 	@echo "$(YELLOW)Compiling: $< $(DEF_COLOR)"
 
-all: $(NAME) bonus
-
-bonus: $(NAME) $(BONUS_OBJ)
-	ar rcs $(NAME) $(BONUS_OBJ)
+all: $(NAME)
 
 $(NAME): $(OBJ)
 	ar rcs $(NAME) $(OBJ)

--- a/src/main/loop.c
+++ b/src/main/loop.c
@@ -3,11 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   loop.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/28 12:54:15 by hmunoz-g         ###   ########.fr       */
-/*   Updated: 2024/11/27 18:48:50 by nponchon         ###   ########.fr       */
+/*   Updated: 2024/11/28 18:37:25 by nponchon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +65,7 @@ void	ms_main_loop(t_list *ms_env)
 			ms_exit_handler("exit", ms_env);
 		}
 		add_history(input);
-		ms_tokenizer(input);
+		ms_tokenizer(ms_env, input);
 		free(input);
 	}
 }

--- a/src/main/prompt_utils.c
+++ b/src/main/prompt_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt_utils.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/28 12:53:16 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/28 13:00:46 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/11/28 15:49:47 by nponchon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -120,5 +120,6 @@ char	*ms_build_prompt(t_list *ms_env)
 	tmp = ft_strjoin(prompt, "$ ");
 	free(prompt);
 	free(username);
+	free(cwd);
 	return (tmp);
 }

--- a/src/parser/expand_variable.c
+++ b/src/parser/expand_variable.c
@@ -1,0 +1,116 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_variable.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/11/28 19:35:12 by nponchon          #+#    #+#             */
+/*   Updated: 2024/11/28 20:01:41 by nponchon         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+/*	Current state of things: the function looks up any $VAR string from
+	the input in the envp. In case of exact match, the input is rewritten
+	with expanded var, 	or with NULL if not found.
+	!This does not take possible quotes or exceptions ($? etc) into account yet.
+	*/
+
+char	*ms_replace_expanded(char *str, char *key, char *var)
+{
+	char	*new;
+	int		i;
+	int		j;
+	int		k;
+
+	i = -1;
+	j = -1;
+	var += ft_strlen(key) + 1;
+	new = (char *)malloc(sizeof(char) * (ft_strlen(str) \
+		+ ft_strlen(var) - ft_strlen(key)) + 1);
+	if (!new)
+		return (NULL);
+	while (str[++i] != '$')
+		new[i] = str[i];
+	while (var[++j])
+		new[i + j] = var[j];
+	k = ft_strlen(key) + i;
+	while (str[++k])
+		new[i + j++] = str[k];
+	new[i + j] = '\0';
+	return (new);
+}
+
+char	*ms_replace_null_value(char *str, char *key)
+{
+	char	*new;
+	int		i;
+
+	i = -1;
+	new = (char *)malloc(sizeof(char) * (ft_strlen(str) \
+		- ft_strlen(key)) + 2);
+	if (!new)
+		return (NULL);
+	while (str[++i] != '$')
+		new[i] = str[i];
+	str += ft_strlen(key) + 1;
+	while (str[i])
+	{
+		new[i] = str[i];
+		i++;
+	}
+	new[i] = '\0';
+	return (new);
+}
+
+int	ms_key_checker(char *key, const char *var)
+{
+	int	i;
+
+	i = -1;
+	while (key[++i])
+	{
+		if (key[i] != var[i])
+			return (0);
+		if (key[i + 1] == '\0' && var[i + 1] == '=')
+			return (1);
+	}
+	return (0);
+}
+
+char	*ms_search_env(t_list *ms_env, char *str, int start)
+{
+	char	*key;
+	char	*tmp;
+
+	tmp = ft_strdup(str);
+	if (ms_env == NULL)
+		return (0);
+	key = strtok(tmp + start + 1, " ");
+	while (ms_env != NULL)
+	{
+		if (ms_key_checker(key, ms_env->content))
+		{
+			str = ms_replace_expanded(str, key, ms_env->content);
+			return (str);
+		}
+		ms_env = ms_env->next;
+	}
+	str = ms_replace_null_value(str, key);
+	return (str);
+}
+
+char	*ms_expand_variable(t_list *ms_env, char *str)
+{
+	int		i;
+
+	i = -1;
+	while (str[++i])
+	{
+		if (str[i] == '$' && ft_isalnum(str[i + 1]))
+			str = ms_search_env(ms_env, str, i);
+	}
+	return (str);
+}

--- a/src/parser/syntax_checker.c
+++ b/src/parser/syntax_checker.c
@@ -6,7 +6,7 @@
 /*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/27 18:00:39 by nponchon         ###   ########.fr       */
+/*   Updated: 2024/11/28 17:02:24 by nponchon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@
 	- Check for special characters ('\', '\n', ';' etc.)
 */
 
-void	ms_checkquotes(char *str, char c)
+int	ms_checkquotes(char *str, char c)
 {
 	int	i;
 	int	flag;
@@ -39,10 +39,14 @@ void	ms_checkquotes(char *str, char c)
 			flag = 1;
 	}
 	if (flag)
-		ft_putstr_fd("Wrong pipe: no command before \"|\"\n", 2);
+	{
+		ft_putstr_fd("Error: unclosed quote\n", 2);
+		return (0);
+	}
+	return (1);
 }
 
-void	ms_checkspecialchar(char *str)
+int	ms_checkspecialchar(char *str)
 {
 	int	i;
 
@@ -50,11 +54,36 @@ void	ms_checkspecialchar(char *str)
 	while (str[++i])
 	{
 		if (str[i] == 59 || str[i] == 92)
+		{
 			ft_putstr_fd("Invalid character: ';' '\\'\n", 2);
+			return (0);
+		}
 	}
+	return (1);
 }
 
-void	ms_checkpipes(char *str)
+int	ms_check_empty_pipe(char *str)
+{
+	str++;
+	while (ft_isspace(*str))
+	{
+		str++;
+	}
+	if (*str == '|')
+		return (1);
+	else if (*str == '\0')
+	{
+		ms_error_handler("Wrong pipe: no command after \"|\"", 0);
+		return (1);
+	}
+	else
+		return (0);
+}
+
+/*	Note: even though the input is trimmed, there can be tabs at the
+	head and/or tail of the string, hence the ft_isspace()	*/
+
+int	ms_checkpipes(char *str)
 {
 	int	i;
 
@@ -63,19 +92,34 @@ void	ms_checkpipes(char *str)
 		;
 	if (str[i] == '|')
 	{
-		ft_putstr_fd("Wrong pipe: no command before \"|\"\n", 2);
-		return ;
+		ms_error_handler("Wrong pipe: no command before \"|\"", 0);
+		return (0);
 	}
 	while (str[i++])
-		;
-	if (str[i - 2] == '|')
-		ft_putstr_fd("Wrong pipe: no command after \"|\"\n", 2);
+	{
+		if (str[i] == '|')
+		{
+			if (ms_check_empty_pipe(str + i))
+			{
+				ms_error_handler("Wrong pipe: empty pipe \"|\"", 0);
+				return (0);
+			}
+		}
+	}
+	return (1);
 }
+
+/*	Each check function returns in case of invalid syntax so as to avoid
+	printing multiple error msgs	*/
 
 void	ms_syntax_checker(char *str)
 {
-	ms_checkquotes(str, 39);
-	ms_checkquotes(str, 34);
-	ms_checkpipes(str);
-	ms_checkspecialchar(str);
+	if (!ms_checkquotes(str, 39))
+		return ;
+	if (!ms_checkquotes(str, 34))
+		return ;
+	if (!ms_checkpipes(str))
+		return ;
+	if (!ms_checkspecialchar(str))
+		return ;
 }

--- a/src/parser/tokenizer.c
+++ b/src/parser/tokenizer.c
@@ -6,13 +6,14 @@
 /*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/27 15:18:18 by nponchon         ###   ########.fr       */
+/*   Updated: 2024/11/28 20:02:42 by nponchon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-void	ms_tokenizer(char *str)
+void	ms_tokenizer(t_list *ms_env, char *str)
 {
 	ms_syntax_checker(str);
+	str = ms_expand_variable(ms_env, str);
 }


### PR DESCRIPTION
Current state of things:

- A simple string with a variable existing in the envp list gets expanded to its corresponding value
- If the variable does not exist, it is replaced by NULL (literally deleted) within the input
- In case of a single $, nothing happens
- This does not take cornercases, quotes or special items (eg. '$?') into account yet.
![image](https://github.com/user-attachments/assets/8e0e31d5-de66-4bf0-9156-bafb452e7a99)
