### PR TITLE
The execution era has begun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,12 @@ SRC 		:= 	main/minishell.c 			\
 				builtins/echo.c 			\
 				builtins/env.c 				\
 				builtins/exit.c 			\
-				builtins/export_utils.c 	\
+				builtins/export_utils1.c 	\
+				builtins/export_utils2.c 	\
 				builtins/export.c 			\
 				executor/executor.c			\
+				executor/executor_utils1.c	\
+				executor/executor_utils2.c	\
 				executor/piping.c 			\
 				executor/redirection.c 		\
 				parser/parser.c 			\

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:07:08 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 18:24:46 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 20:10:05 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 # include <readline/readline.h>
 # include <readline/history.h>
 # include <sys/stat.h>
+# include <sys/wait.h>
 # include <errno.h>
 
 # define TRUE 1
@@ -91,31 +92,44 @@ int		ms_checkredirections(t_ms *ms, char *str);
 //ERROR and EXIT HANDLER functions
 void	ms_error_handler(t_ms *ms, char *msg, int critical);
 void	ms_exit_handler(t_ms *ms, const char *msg, int code);
-void	ms_exit(t_ms *ms, char **args);
+void	ms_exit(t_ms *ms, t_list *tokens);
 
 //SIGNAL HANDLER functions
 void	ms_signal_handler(int signal);
 void	ms_sigtstp_handler(void);
 void	ms_sigint_handler(void);
 void	ms_sigquit_handler(void);
+int		ms_get_set(int flag, int val);
 
 //ENVIRONMENT COPY and MANAGEMENT functions
 t_list	*ms_copy_env(t_ms *ms, char **env);
-void	ms_add_env_variable(t_ms *ms, const char *env_var);
+char	*ms_build_entry(char *key, char *value);
+char	*ms_get_env_variable(t_ms *ms, char *key);
+void	ms_set_env_variable(t_ms *ms, char *key, char *value);
+void	ms_add_env_variable(t_ms *ms, char *key, char *value);
 char	*ms_create_user_entry(t_ms *ms);
 char	*ms_create_pwd_entry(t_ms *ms, char *cwd);
 char	*ms_get_prompt_user(t_ms *ms);
 char	*ms_username_from_psswd(t_ms *ms);
-char	*ms_get_env_variable(t_ms *ms, const char *var_name);
 char	*ms_get_cwd(t_ms *ms);
 char	*ms_get_hostname(char *session_manager, t_ms *ms);
 char	*ms_get_username(t_ms *ms);
-void	ms_set_env_variable(t_ms *ms, char *key, char *value);
 char	*ms_make_home_ref(t_ms *ms, char **env);
 char	*ms_get_parent_path(t_ms *ms, char *cwd);
 
 //EXECUTOR functions
 void	ms_executor(t_ms *ms);
+void	execute_parent(pid_t pid, int *status);
+void	execute_child(t_ms *ms, char **arr);
+char	*ms_get_command_path(t_ms *ms, char *cmd);
+char	**ms_make_argv(t_ms *ms, t_list *tokens);
+void	ms_execute_builtin(t_ms *ms);
+int		ms_is_builtin(char *cmd);
+void	ms_child_process(t_ms *ms, char **arr);
+void	ms_parent_process(pid_t pid, int *status);
+void	ms_executor_cleanup(t_ms *ms, char **arr);
+char	**ms_env_to_array(t_list *ms_env);
+char	*validate_command(t_ms *ms);
 
 //BUILTIN CD functions
 void	ms_cd(t_ms *ms, char *path);
@@ -142,17 +156,19 @@ int		ms_update_oldpwd(t_ms *ms, char *current_pwd);
 //ENV, PWD, UNSET, ECHO and EXPORT builtin functions
 void	ms_env(t_ms *ms);
 void	ms_pwd(t_ms *ms);
-void	ms_unset(t_ms *ms, char **args);
-void	ms_echo(t_ms *ms, char **args);
-void	ms_export(t_ms *ms, char **input);
+void	ms_unset(t_ms *ms, t_list *tokens);
+void	ms_echo(t_list *tokens);
+void	ms_export(t_ms *ms, t_list *tokens);
 void	ms_export_ex(t_ms *ms, char *key, char *value);
 void	ms_export_error(t_ms *ms, char *entry);
 int		ms_export_check(const char *var);
 void	ms_export_print(t_ms *ms);
+char	*ms_build_export_output(t_ms *ms, char *content, char *sym);
 void	ms_process_export_arg(t_ms *ms, char *arg);
 void	ms_export_with_value(t_ms *ms, char *arg, char *sign);
 void	ms_export_without_value(t_ms *ms, char *arg);
 t_list	*ms_sort(t_list *lst, int (*cmp)(const void *, const void *, size_t));
+int		ms_key_exists(t_ms *ms, char *key);
 
 //GARBAGE COLLECTOR functions
 void	gc_add(void *ptr, t_list **gc);

--- a/libs/libft/Makefile
+++ b/libs/libft/Makefile
@@ -22,8 +22,8 @@ SRC = ft_itoa.c ft_strchr.c ft_strdup.c ft_strjoin.c ft_strjoin_free.c ft_strmap
       ft_append_c.c cucufu.c ft_print_array.c ft_strtok.c                 \
       ft_lstnew_bonus.c ft_lstadd_front_bonus.c ft_lstlast_bonus.c \
       ft_lstadd_back_bonus.c ft_lstdelone_bonus.c ft_lstclear_bonus.c \
-      ft_lstiter_bonus.c ft_lstmap_bonus.c ft_lstsize_bonus.c ft_strrchr_n.c \
-      ft_strspn.c ft_strcspn.c ft_strchr_n.c ft_isdigit_str.c
+      ft_lstiter_bonus.c ft_lstmap_bonus.c ft_lstsize_bonus.c ft_lstcpy_bonus.c \
+      ft_strrchr_n.c ft_strspn.c ft_strcspn.c ft_strchr_n.c ft_isdigit_str.c ft_strjoin3.c
 
 OBJ = $(SRC:.c=.o)
 

--- a/libs/libft/ft_lstclear_bonus.c
+++ b/libs/libft/ft_lstclear_bonus.c
@@ -6,7 +6,7 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/20 10:06:46 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 14:02:07 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 10:44:50 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,6 @@ void	ft_lstclear(t_list **lst, void (*del)(void *))
 	while (*lst)
 	{
 		tmp = (*lst)->next;
-		//(void)(*del);
 		if (del)
 			del((*lst)->content);
 		free(*lst);

--- a/libs/libft/ft_lstcpy_bonus.c
+++ b/libs/libft/ft_lstcpy_bonus.c
@@ -1,39 +1,30 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_strjoin.c                                       :+:      :+:    :+:   */
+/*   ft_lstcpy_bonus.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/09/16 17:42:02 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/12 09:57:51 by hmunoz-g         ###   ########.fr       */
+/*   Created: 2024/09/20 10:14:51 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2024/12/12 12:05:37 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-char	*ft_strjoin(char *s1, const char *s2)
+t_list	*ft_lstcpy(t_list *original)
 {
-	char	*str;
-	size_t	i;
-	size_t	c;
+	t_list	*new_list;
+	t_list	*new_node;
 
-	if (!s1)
+	new_list = NULL;
+	while (original)
 	{
-		s1 = malloc(sizeof(char) + 1);
-		if (!s1)
-			return (0);
-		s1[0] = 0;
+		new_node = ft_lstnew(ft_strdup(original->content));
+		if (!new_node)
+			return (NULL);
+		ft_lstadd_back(&new_list, new_node);
+		original = original->next;
 	}
-	str = (char *)malloc(sizeof(char) * ft_strlen(s1) + ft_strlen(s2) + 1);
-	if (!str)
-		return (ft_free_gnl(&s1));
-	i = -1;
-	while (s1[++i])
-		str[i] = s1[i];
-	c = -1;
-	while (s2[++c])
-		str[i + c] = s2[c];
-	str[i + c] = '\0';
-	return (str);
+	return (new_list);
 }

--- a/libs/libft/ft_strjoin3.c
+++ b/libs/libft/ft_strjoin3.c
@@ -1,39 +1,32 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_strjoin.c                                       :+:      :+:    :+:   */
+/*   ft_strjoin3.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 17:42:02 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/12 09:57:51 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 16:44:25 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-char	*ft_strjoin(char *s1, const char *s2)
+char	*ft_strjoin3(char *s1, char *s2, char *s3)
 {
-	char	*str;
-	size_t	i;
-	size_t	c;
+	size_t	len1;
+	size_t	len2;
+	size_t	len3;
+	char	*result;
 
-	if (!s1)
-	{
-		s1 = malloc(sizeof(char) + 1);
-		if (!s1)
-			return (0);
-		s1[0] = 0;
-	}
-	str = (char *)malloc(sizeof(char) * ft_strlen(s1) + ft_strlen(s2) + 1);
-	if (!str)
-		return (ft_free_gnl(&s1));
-	i = -1;
-	while (s1[++i])
-		str[i] = s1[i];
-	c = -1;
-	while (s2[++c])
-		str[i + c] = s2[c];
-	str[i + c] = '\0';
-	return (str);
+	len1 = ft_strlen(s1);
+	len2 = ft_strlen(s2);
+	len3 = ft_strlen(s3);
+	result = malloc(len1 + len2 + len3 + 1);
+	if (result == NULL)
+		return (NULL);
+	ft_strlcpy(result, s1, len1 + 1);
+	ft_strlcpy(result + len1, s2, len2 + 1);
+	ft_strlcpy(result + len1 + len2, s3, len3 + 1);
+	return (result);
 }

--- a/libs/libft/libft.h
+++ b/libs/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/27 12:45:35 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/09 13:59:37 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 16:44:33 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,8 +42,9 @@ typedef struct s_list
 char	*ft_itoa(int n);
 char	*ft_strchr(const char *s, int c);
 char	*ft_strdup(const char *s);
-char	*ft_strjoin(char *s1, char *s2);
+char	*ft_strjoin(char *s1, const char *s2);
 char	*ft_strjoin_free(char *s1, char *s2);
+char	*ft_strjoin3(char *s1, char *s2, char *s3);
 char	*ft_strmapi(char const *s, char (*f)(unsigned int, char));
 char	*ft_strnstr(const char *big, const char *little, size_t len);
 char	*ft_strrchr(const char *s, int c);
@@ -86,6 +87,7 @@ void	ft_lstdelone(t_list *lst, void (*del)(void *));
 void	ft_lstclear(t_list **lst, void (*del)(void *));
 void	ft_lstiter(t_list *lst, void (*f)(void *));
 t_list	*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *));
+t_list	*ft_lstcpy(t_list *original);
 
 int		ft_printf(char const *str, ...);
 ssize_t	ft_write_str(char *str);

--- a/src/builtins/cd_utils1.c
+++ b/src/builtins/cd_utils1.c
@@ -6,12 +6,18 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/03 15:49:43 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 14:06:53 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 09:47:19 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Bypass function that expands the initial portion of a path starting with '~'.
+'~' is a substitution character for /home/user,
+	so this is a normalizing step that makes minishell able to accept
+		cd paths with '~' abbreviation.
+*/
 char	*ms_expand_tilde(t_ms *ms, char *path)
 {
 	char	*expanded_path;
@@ -27,6 +33,9 @@ char	*ms_expand_tilde(t_ms *ms, char *path)
 	return (path);
 }
 
+/*
+Bypass function to join paths in case of inserted '..' or '.' in argument path.
+*/
 int	ms_join_paths(t_ms *ms, char *cwd, char *path, char **new_path)
 {
 	size_t	cwd_len;
@@ -46,13 +55,19 @@ int	ms_join_paths(t_ms *ms, char *cwd, char *path, char **new_path)
 	return (0);
 }
 
+/*
+The heart of the cd builtin command.
+Attempts to change directory to path received as argument.
+Handles change attempt error both with output and int return.
+Handles the necessary changes to PWD and OLDPWD ms_env entries, if set.
+*/
 int	ms_change_directory(t_ms *ms, char *new_path)
 {
 	char	*current_pwd;
 
 	if (ms_check_directory_access(ms, new_path) == -1)
 		return (-1);
-	current_pwd = ms_get_env_variable(ms, "PWD=");
+	current_pwd = ms_get_env_variable(ms, "PWD");
 	if (!current_pwd)
 	{
 		current_pwd = ms_get_cwd(ms);
@@ -67,6 +82,10 @@ int	ms_change_directory(t_ms *ms, char *new_path)
 	return (0);
 }
 
+/*
+Flow control function to check for cwd availability.
+Outputs error if cwd ins unreachable (being in a non-existing dir case).
+*/
 char	*ms_getcwd_or_error(t_ms *ms)
 {
 	char	*cwd;
@@ -81,16 +100,11 @@ char	*ms_getcwd_or_error(t_ms *ms)
 	return (cwd);
 }
 
+/*
+Handles cding to root directory (case cd /).
+*/
 void	ms_cd_root(t_ms *ms, char *path)
 {
-	char	*old_cwd;
-	char	*cwd;
-
-	old_cwd = ms_get_cwd(ms);
-	if (old_cwd)
-		gc_add(old_cwd, &ms->gc);
-	ms_change_directory(ms, path);
-	cwd = ms_getcwd_or_error(ms);
-	if (cwd)
-		gc_add(cwd, &ms->gc);
+	if (ms_change_directory(ms, path) == -1)
+		return ;
 }

--- a/src/builtins/cd_utils2.c
+++ b/src/builtins/cd_utils2.c
@@ -6,12 +6,17 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/04 14:30:06 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 14:08:06 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 09:47:18 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Helper function that pops a segment from a cd path.
+It is called if path contains inserted "..", and takes out
+	the preceding segment of said path.
+*/
 char	*ms_pop_from_path(char *path)
 {
 	int		len;
@@ -27,6 +32,11 @@ char	*ms_pop_from_path(char *path)
 	return (path);
 }
 
+/*
+Special helper case that returns either the cwd or the root path ("/").
+This is a safe mechanism so that Minishell can find at least one safe route,
+	even in extreme cases (like no-env cding from non-existing dirs).
+*/
 char	*ms_get_cwd_or_root(char *path)
 {
 	char	cwd[PATH_MAX];
@@ -38,6 +48,11 @@ char	*ms_get_cwd_or_root(char *path)
 	return (ft_strdup(cwd));
 }
 
+/*
+Helper function that handles inserted '..' and '.' segments in cd path.
+If '..', calls pop function.
+if '.', cleans the segment (it's existance has no impact in the final path).
+*/
 char	*ms_process_component(char *normalized, char *component, t_ms *ms)
 {
 	if (!ft_strncmp(component, "..", 2))
@@ -55,6 +70,12 @@ char	*ms_process_component(char *normalized, char *component, t_ms *ms)
 	return (normalized);
 }
 
+/*
+Flow control path normalization function.
+Makes every non-special path (ms_cd head cases) into a working absolute path.
+Breaks paths into components, which are processed with helper function.
+Returns a rebuild path from normalized components.
+*/
 char	*ms_normalize_path(t_ms *ms, char *path)
 {
 	char	*normalized;
@@ -83,6 +104,11 @@ char	*ms_normalize_path(t_ms *ms, char *path)
 	return (normalized);
 }
 
+/*
+Special case handling function.
+It is called from ms_cd_parent if direct parent is unreachable.
+Searches for closest available parent directory and attempts to move there.
+*/
 void	ms_cd_ascend(t_ms *ms)
 {
 	char	*cwd;
@@ -108,6 +134,6 @@ void	ms_cd_ascend(t_ms *ms)
 		cwd = ft_substr(cwd, 0, ft_strrchr(cwd, '/') - cwd);
 		gc_add(cwd, &ms->gc);
 	}
-	if (ms_get_env_variable(ms, "PWD="))
+	if (ms_get_env_variable(ms, "PWD"))
 		ms_set_env_variable(ms, "PWD", cwd);
 }

--- a/src/builtins/cd_utils3.c
+++ b/src/builtins/cd_utils3.c
@@ -6,12 +6,15 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/06 14:37:10 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 14:09:22 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/11 12:53:54 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Checks if path is symlink, returning 0 or confirmation.
+*/
 int	ms_is_symlink(char *path)
 {
 	struct stat	path_stat;
@@ -21,6 +24,12 @@ int	ms_is_symlink(char *path)
 	return (S_ISLNK(path_stat.st_mode));
 }
 
+/*
+Helper function that makes minishell able to handle symlinks.
+Using the ms_is_symlink function, returns the resolve symlink path.
+	(This means that if symlink, the resolved path has symlink ref;
+	if not, the resolved path has objective dir ref).
+*/
 char	*ms_resolve_symlink(t_ms *ms, char *symlink)
 {
 	char	*cwd;
@@ -48,6 +57,9 @@ char	*ms_resolve_symlink(t_ms *ms, char *symlink)
 	return (resolved_path);
 }
 
+/*
+Helper function that returns parent path from the CWD.
+*/
 char	*ms_get_parent_path(t_ms *ms, char *cwd)
 {
 	cwd = ms_expand_tilde(ms, cwd);
@@ -67,6 +79,10 @@ char	*ms_get_parent_path(t_ms *ms, char *cwd)
 	return (cwd);
 }
 
+/*
+Helper function to check if attempted cd path is a directory.
+It is used to handle specific cd error outputs.
+*/
 int	ms_cd_isdirectory(t_ms *ms, char *path)
 {
 	struct stat	path_stat;

--- a/src/builtins/cd_utils4.c
+++ b/src/builtins/cd_utils4.c
@@ -6,12 +6,16 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/10 11:23:05 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 15:49:20 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 11:18:23 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Helper function to check cd path's aiming dir availability.
+Handles different possible error cases.
+*/
 int	ms_check_directory_access(t_ms *ms, char *new_path)
 {
 	if (access(new_path, F_OK) == -1)
@@ -25,19 +29,19 @@ int	ms_check_directory_access(t_ms *ms, char *new_path)
 	return (0);
 }
 
+/*
+Helper function that updates the OLDPWD entry in ms_env struct.
+If OLDPWD is unset, this makes it's resetting possible.
+It is a tool function to remake the OLDPWD in an unset env case.
+	I.E., if unset OLDPWD, this makes it reset possible after 2 cds.
+*/
 int	ms_update_oldpwd(t_ms *ms, char *current_pwd)
 {
-	char	*old_pwd;
-
 	if (access(current_pwd, F_OK) != -1)
 	{
-		if (!ms_get_env_variable(ms, "OLDPWD="))
+		if (!ms_get_env_variable(ms, "OLDPWD"))
 		{
-			old_pwd = ft_strjoin("OLDPWD=", current_pwd);
-			if (!old_pwd)
-				return (ms_error_handler(ms, "cd: Memory alloc failed", 1), -1);
-			gc_add(old_pwd, &ms->gc);
-			ms_add_env_variable(ms, old_pwd);
+			ms_add_env_variable(ms, "OLDPWD", current_pwd);
 		}
 		else
 		{

--- a/src/builtins/echo.c
+++ b/src/builtins/echo.c
@@ -6,32 +6,41 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:42:26 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 12:12:25 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 12:21:40 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-void	ms_echo(t_ms *ms, char **args)
+/*
+ECHO builtin command main handler.
+Right now, it manages -n flag and prints tokens.
+Tokens that need expansion are received already expanded.
+TODO: handle cases with multiple -n
+TODO: correctly echo arguments like (echo '"hola'$USER'$USER"') (without spaces)
+*/
+void	ms_echo(t_list *tokens)
 {
 	int		n_flag;
-	int		i;
+	t_list	*current;
 
-	(void)ms;
 	n_flag = 0;
-	i = 1;
-	if (args[i] && !ft_strncmp(args[i], "-n", 2))
+	current = tokens->next;
+	if (tokens->next && !ft_strncmp(tokens->next->content, "-n", 2))
 	{
 		n_flag = 1;
-		i++;
+		current = current->next;
 	}
-	while (args[i])
+	if (current->content)
 	{
-		ft_putstr_fd(args[i], 1);
-		if (args[i + 1])
-			ft_putchar_fd(' ', 1);
-		i++;
+		while (current)
+		{
+			ft_putstr_fd(current->content, 1);
+			if (current->next)
+				ft_putchar_fd(' ', 1);
+			current = current->next;
+		}
+		if (!n_flag)
+			ft_putchar_fd('\n', 1);
 	}
-	if (!n_flag)
-		ft_putchar_fd('\n', 1);
 }

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -6,12 +6,17 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:42:26 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 17:19:30 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 09:47:48 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+ENV builtin command handler.
+Prints the env variables with set up values inside the ms_env struct.
+(Existing variables with no value are handled by EXPORT builtin)
+*/
 void	ms_env(t_ms *ms)
 {
 	t_list	*current;
@@ -25,13 +30,20 @@ void	ms_env(t_ms *ms)
 	}
 }
 
+/*
+PWD builtin command handler.
+Retrieves the CWD and prints it, with 3 possible cases:
+	-If env is set and has a PWD entry, returns its value.
+	-If this fails, tries to get the cwd by calling getcwd.
+	-If no PWD/CWD can be retrieved, outputs a non-critical error.
+*/
 void	ms_pwd(t_ms *ms)
 {
 	char	*cwd;
 
-	if (ms_get_env_variable(ms, "PWD="))
+	if (ms_get_env_variable(ms, "PWD"))
 	{
-		ft_printf("%s\n", ms_get_env_variable(ms, "PWD="));
+		ft_printf("%s\n", ms_get_env_variable(ms, "PWD"));
 		return ;
 	}
 	else
@@ -48,18 +60,24 @@ void	ms_pwd(t_ms *ms)
 	ms_error_handler(ms, "pwd: Cannot retrieve current directory", 0);
 }
 
-void	ms_unset(t_ms *ms, char **args)
+/*
+UNSET builtin command handler.
+Searches for variable name in env list (ms_env).
+If found, pops it out of the list (handling links).
+*/
+void	ms_unset(t_ms *ms, t_list *tokens)
 {
 	t_list	*current;
 	t_list	*previous;
 
-	if (!ms->ms_env || !args[1] || ft_strchr(args[1], '='))
+	if (!ms->ms_env || !tokens->next || ft_strchr(tokens->next->content, '='))
 		return ;
 	current = ms->ms_env;
 	previous = NULL;
 	while (current)
 	{
-		if (!ft_strncmp(current->content, args[1], ft_strlen(args[1])))
+		if (!ft_strncmp(current->content,
+				tokens->next->content, ft_strlen(tokens->next->content)))
 		{
 			if (previous == NULL)
 				ms->ms_env = current->next;

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,15 +6,17 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:42:26 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 18:28:46 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/11 11:59:33 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
 /*
-Small exit handler that prints an exit msg, cleans ms_env and exits.
-If needed later on, we can move this to it's own file in utils.
+Exit handler.
+Only non-error exit point for minishell, reached by exit input or ctrl+D.
+Prints exit string ("exit"), cleans structs and memory.
+Sets an exit code if provided (checkable with echo $?)
 */
 void	ms_exit_handler(t_ms *ms, const char *msg, int code)
 {
@@ -22,23 +24,28 @@ void	ms_exit_handler(t_ms *ms, const char *msg, int code)
 		ft_printf("%s\n", msg);
 	ft_lstclear(&ms->ms_env, free);
 	ft_lstclear(&ms->gc, free);
-	ft_lstclear(&ms->tokens, free);
+	if (ft_lstsize(ms->tokens))
+		ft_lstclear(&ms->tokens, free);
 	exit(code);
 }
 
-void	ms_exit(t_ms *ms, char **args)
+/*
+Exit builtin command intermediary.
+Checks arguments, handles the exit code, calls handler.
+*/
+void	ms_exit(t_ms *ms, t_list *tokens)
 {
 	int		code;
 
-	if (ft_array_count(args) >= 3)
+	if (ft_lstsize(tokens) >= 3)
 	{
 		ms_error_handler(ms, "exit: too many arguments", 0);
 		return ;
 	}
-	else if (ft_array_count(args) == 2)
+	else if (ft_lstsize(tokens) == 2)
 	{
-		if (ft_isdigit_str(args[1]))
-			code = ft_atoi(args[1]) % 256;
+		if (ft_isdigit_str(tokens->next->content))
+			code = ft_atoi(tokens->next->content) % 256;
 		else
 		{
 			ms_error_handler(ms, "exit: numeric argument required", 0);
@@ -48,6 +55,5 @@ void	ms_exit(t_ms *ms, char **args)
 	else
 		code = 0;
 	ms_exit_handler(ms, "exit", code);
-	ft_free(args);
 	return ;
 }

--- a/src/builtins/export_utils1.c
+++ b/src/builtins/export_utils1.c
@@ -1,17 +1,20 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   export_utils.c                                     :+:      :+:    :+:   */
+/*   export_utils1.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/10 17:59:38 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 18:04:18 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 10:49:18 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Flow control function to differentiate export cases with and w/o value.
+*/
 void	ms_process_export_arg(t_ms *ms, char *arg)
 {
 	char	*sign;
@@ -25,6 +28,11 @@ void	ms_process_export_arg(t_ms *ms, char *arg)
 		ms_export_without_value(ms, arg);
 }
 
+/*
+Helper to export (set or create) variables with set values.
+Calls export check function, and if passed goes to export executor.
+If key doesn't pass the checks, the export error function is called.
+*/
 void	ms_export_with_value(t_ms *ms, char *arg, char *sign)
 {
 	char	*key;
@@ -40,6 +48,12 @@ void	ms_export_with_value(t_ms *ms, char *arg, char *sign)
 		ms_export_error(ms, arg);
 }
 
+/*
+Helper to export (set or create) variables without set values.
+Key is checked to comply with export rules. 
+If checks are passed, export execution is called.
+Else, export error is called. 
+*/
 void	ms_export_without_value(t_ms *ms, char *arg)
 {
 	if (ms_export_check(arg))
@@ -48,6 +62,10 @@ void	ms_export_without_value(t_ms *ms, char *arg)
 		ms_export_error(ms, arg);
 }
 
+/*
+Helper function to alphabetically sort a list.
+Needed for export because the printed list must be alphabetically sorted.
+*/
 t_list	*ms_sort(t_list *lst, int (*cmp)(const void *, const void *, size_t))
 {
 	char	*aux;
@@ -75,4 +93,27 @@ t_list	*ms_sort(t_list *lst, int (*cmp)(const void *, const void *, size_t))
 			lst = lst->next;
 	}
 	return (start);
+}
+
+/*
+Flow control function that builds the export output.
+It builds said output mimicking bash, enclosing value in between "".
+*/
+char	*ms_build_export_output(t_ms *ms, char *content, char *sym)
+{
+	char	*key;
+	char	*value;
+	char	*out;
+
+	key = ft_substr(content, 0, sym - content);
+	gc_add(key, &ms->gc);
+	value = ft_strdup(sym + 1);
+	gc_add(value, &ms->gc);
+	out = ft_strjoin(key, "=\"");
+	gc_add(out, &ms->gc);
+	out = ft_strjoin(out, value);
+	gc_add(out, &ms->gc);
+	out = ft_strjoin(out, "\"");
+	gc_add(out, &ms->gc);
+	return (out);
 }

--- a/src/builtins/export_utils2.c
+++ b/src/builtins/export_utils2.c
@@ -1,39 +1,30 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_strjoin.c                                       :+:      :+:    :+:   */
+/*   export_utils2.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/09/16 17:42:02 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/12 09:57:51 by hmunoz-g         ###   ########.fr       */
+/*   Created: 2024/12/10 17:59:38 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2024/12/12 10:47:51 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "libft.h"
+#include "../../includes/minishell.h"
 
-char	*ft_strjoin(char *s1, const char *s2)
+/*
+Helper function that cheks if ms_env has an entry with argument key.
+*/
+int	ms_key_exists(t_ms *ms, char *key)
 {
-	char	*str;
-	size_t	i;
-	size_t	c;
+	t_list	*current;
 
-	if (!s1)
+	current = ms->ms_env;
+	while (current)
 	{
-		s1 = malloc(sizeof(char) + 1);
-		if (!s1)
-			return (0);
-		s1[0] = 0;
+		if (!ft_strncmp(current->content, key, ft_strlen(key)))
+			return (1);
+		current = current->next;
 	}
-	str = (char *)malloc(sizeof(char) * ft_strlen(s1) + ft_strlen(s2) + 1);
-	if (!str)
-		return (ft_free_gnl(&s1));
-	i = -1;
-	while (s1[++i])
-		str[i] = s1[i];
-	c = -1;
-	while (s2[++c])
-		str[i + c] = s2[c];
-	str[i + c] = '\0';
-	return (str);
+	return (0);
 }

--- a/src/env/env_utils.c
+++ b/src/env/env_utils.c
@@ -6,12 +6,16 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:42:26 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 10:23:03 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 09:48:31 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Prompt helper function used as fallback if username retrieval fails.
+Goes to the /etc/passwd file and extracts "root" value from its content.
+*/
 char	*ms_username_from_psswd(t_ms *ms)
 {
 	int		fd;
@@ -41,6 +45,10 @@ char	*ms_username_from_psswd(t_ms *ms)
 	return (username);
 }
 
+/*
+Prompt helper function to build the username+hostname chunk of the prompt.
+Calls username and hostname functions, concatenates return values.
+*/
 char	*ms_get_prompt_user(t_ms *ms)
 {
 	char	*username;
@@ -54,7 +62,7 @@ char	*ms_get_prompt_user(t_ms *ms)
 	username = ms_get_username(ms);
 	if (!username)
 		username = "user";
-	session_manager = ms_get_env_variable(ms, "SESSION_MANAGER=");
+	session_manager = ms_get_env_variable(ms, "SESSION_MANAGER");
 	if (session_manager)
 		hostname = ms_get_hostname(session_manager, ms);
 	if (!hostname)
@@ -68,6 +76,10 @@ char	*ms_get_prompt_user(t_ms *ms)
 	return (prompt_user);
 }
 
+/*
+Prompt helper function to get the hostname from the session_manager.
+If retrieval fails, falls back to a default "localhost" value.
+*/
 char	*ms_get_hostname(char *session_manager, t_ms *ms)
 {
 	char	*start;
@@ -94,13 +106,20 @@ char	*ms_get_hostname(char *session_manager, t_ms *ms)
 	}
 }
 
+/*
+Prompt helper function, also useful for anything that needs the CWD. 
+If ms_env has a PWD variable, returns it's value.
+Else, tries to getcwd().
+Else, falls back to an unknown value ("?"), as Bash does with a "."
+	This is needed for an unset env, non-existing dir minishell execution.
+*/
 char	*ms_get_cwd(t_ms *ms)
 {
 	char	*cwd;
 	char	*new_cwd;
 
-	if (ms_get_env_variable(ms, "PWD="))
-		cwd = ft_strdup(ms_get_env_variable(ms, "PWD="));
+	if (ms_get_env_variable(ms, "PWD"))
+		cwd = ft_strdup(ms_get_env_variable(ms, "PWD"));
 	else
 	{
 		cwd = NULL;
@@ -122,11 +141,15 @@ char	*ms_get_cwd(t_ms *ms)
 	return (cwd);
 }
 
+/*
+Prompt helper function.
+Gets the USER value from ms_env, or calls alternative methods.
+*/
 char	*ms_get_username(t_ms *ms)
 {
 	char	*username;
 
-	username = ms_get_env_variable(ms, "USER=");
+	username = ms_get_env_variable(ms, "USER");
 	if (!username)
 		username = ms_username_from_psswd(ms);
 	if (!username)

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,37 +6,82 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:42:26 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 18:28:41 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 20:15:25 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Searches for commands using the env path.
+If command is not found, returns an error.
+*/
+void	ms_child_process(t_ms *ms, char **arr)
+{
+	char	*cmd_path;
+
+	cmd_path = ms_get_command_path(ms, ms->tokens->content);
+	if (!cmd_path || execve(cmd_path, ms_make_argv(ms, ms->tokens), arr) == -1)
+		ms_error_handler(ms, "Command not found or execve failed", 0);
+	gc_add(cmd_path, &ms->gc);
+}
+
+/*
+Makes the parent process wait until child process ends.
+*/
+void	ms_parent_process(pid_t pid, int *status)
+{
+	waitpid(pid, status, 0);
+	ms_get_set(1, WEXITSTATUS(*status));
+}
+
+/*
+Control flow function that calls for child process execution.
+Rises the flag for the SIGINT handler to know if its in child or parent proc.
+*/
+void	execute_child(t_ms *ms, char **arr)
+{
+	ms_get_set(1, 0);
+	ms_child_process(ms, arr);
+}
+
+/*
+Control flow function that calls for parent process execution.
+Rises the flag for the SIGINT handler to know if its in child or parent proc.
+*/
+void	execute_parent(pid_t pid, int *status)
+{
+	ms_get_set(1, 1);
+	ms_parent_process(pid, status);
+}
+
+/*
+Executor hub.
+Makes some checks to know if it needs to execute a builtin or a system cmd.
+Creates forks for child processes, calls for execution of both child and parent.
+Calls the executor cleanup.
+*/
 void	ms_executor(t_ms *ms)
 {
-	char	**args;
+	pid_t	pid;
+	int		status;
+	char	**arr;
+	char	*path;
 
-	args = ft_split(ms->input, ' ');
-	if (!ft_strncmp(args[0], "cd", 2))
+	arr = ms_env_to_array(ms->ms_env);
+	path = validate_command(ms);
+	if (ms_is_builtin(ms->tokens->content))
+		ms_execute_builtin(ms);
+	else if (path)
 	{
-		if (!args[1] || args[1][0] == ' ')
-			ms_cd(ms, NULL);
-		else if (args[1] && !args[2])
-			ms_cd(ms, args[1]);
+		gc_add(path, &ms->gc);
+		pid = fork();
+		if (pid == -1)
+			ms_error_handler(ms, "Fork failed", 0);
+		else if (pid == 0)
+			execute_child(ms, arr);
 		else
-			ms_error_handler(ms, "cd: invalid args", 0);
+			execute_parent(pid, &status);
 	}
-	else if (!ft_strncmp(args[0], "env", 3))
-		ms_env(ms);
-	else if (!ft_strncmp(args[0], "pwd", 3))
-		ms_pwd(ms);
-	else if (!ft_strncmp(args[0], "unset", 5))
-		ms_unset(ms, args);
-	else if (!ft_strncmp(args[0], "exit", 4))
-		ms_exit(ms, args);
-	else if (!ft_strncmp(args[0], "echo", 4))
-		ms_echo(ms, args);
-	else if (!ft_strncmp(args[0], "export", 6))
-		ms_export(ms, args);
-	ft_free(args);
+	ms_executor_cleanup(ms, arr);
 }

--- a/src/executor/executor_utils1.c
+++ b/src/executor/executor_utils1.c
@@ -1,0 +1,111 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   executor_utils1.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/11/25 11:42:26 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2024/12/12 20:20:18 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+/*
+Helper function to check if input comand is a Minishell builtin.
+*/
+int	ms_is_builtin(char *cmd)
+{
+	return (!ft_strncmp(cmd, "cd", 2)
+		|| !ft_strncmp(cmd, "env", 3)
+		|| !ft_strncmp(cmd, "pwd", 3)
+		|| !ft_strncmp(cmd, "unset", 5)
+		|| !ft_strncmp(cmd, "exit", 4)
+		|| !ft_strncmp(cmd, "echo", 4)
+		|| !ft_strncmp(cmd, "export", 6));
+}
+
+/*
+Helper function that creates the argument array to be sent to a cmd exec.
+*/
+char	**ms_make_argv(t_ms *ms, t_list *tokens)
+{
+	int		count;
+	char	**argv;
+	int		i ;
+
+	count = ft_lstsize(tokens);
+	argv = malloc(sizeof(char *) * (count + 1));
+	if (!argv)
+	{
+		ms_error_handler(ms, "Error: Memory allocation failed", 1);
+		return (NULL);
+	}
+	i = 0;
+	while (tokens)
+	{
+		argv[i++] = ft_strdup(tokens->content);
+		tokens = tokens->next;
+	}
+	argv[i] = NULL;
+	return (argv);
+}
+
+/*
+Flow control function that searches for commands in the system.
+If command exists, returns its path so it can be executed.
+*/
+char	*ms_get_command_path(t_ms *ms, char *cmd)
+{
+	char	**paths;
+	char	*full_path;
+	int		i;
+
+	if (ft_strchr(cmd, '/'))
+		return (ft_strdup(cmd));
+	paths = ft_split(ms_get_env_variable(ms, "PATH"), ':');
+	if (!paths)
+		return (NULL);
+	i = 0;
+	while (paths[i])
+	{
+		full_path = ft_strjoin3(paths[i], "/", cmd);
+		if (access(full_path, X_OK) == 0)
+		{
+			ft_free(paths);
+			return (full_path);
+		}
+		gc_add(full_path, &ms->gc);
+		i++;
+	}
+	ft_free(paths);
+	return (NULL);
+}
+
+/*
+Re-creates an array of env variables from ms_env linked list initial copy.
+It is needed to send to child processes as their env array.
+*/
+char	**ms_env_to_array(t_list *ms_env)
+{
+	int		count;
+	int		i;
+	char	**arr;
+	t_list	*current;
+
+	count = ft_lstsize(ms_env);
+	arr = malloc(sizeof(char *) * (count + 1));
+	i = 0;
+	current = ms_env;
+	if (!arr)
+		return (NULL);
+	while (current)
+	{
+		arr[i] = (char *)current->content;
+		current = current->next;
+		i++;
+	}
+	arr[i] = NULL;
+	return (arr);
+}

--- a/src/executor/executor_utils2.c
+++ b/src/executor/executor_utils2.c
@@ -1,0 +1,67 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   executor_utils2.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/11/25 11:42:26 by hmunoz-g          #+#    #+#             */
+/*   Updated: 2024/12/12 20:22:12 by hmunoz-g         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../includes/minishell.h"
+
+/*
+Helper function to check if an input command exists. 
+It is used to end execution if an invalid command is input.
+*/
+char	*validate_command(t_ms *ms)
+{
+	char	*path;
+
+	path = ms_get_command_path(ms, ms->tokens->content);
+	if (!path)
+		ms_error_handler(ms, "Command not found", 0);
+	return (path);
+}
+
+/*
+Helper function to clear the execution tools (env array for children, tokens).
+*/
+void	ms_executor_cleanup(t_ms *ms, char **arr)
+{
+	free(arr);
+	ft_lstclear(&ms->tokens, free);
+	ms_get_set(1, 0);
+}
+
+/*
+Control flow function that branches builtin execution to each of the
+	builtin commands' specific handler functions.
+*/
+void	ms_execute_builtin(t_ms *ms)
+{
+	if (!ft_strncmp(ms->tokens->content, "cd", 2))
+	{
+		if (!ms->tokens->next
+			|| ((char *)(ms->tokens->next->content))[0] == ' ')
+			ms_cd(ms, NULL);
+		else if (ms->tokens->next && !ms->tokens->next->next)
+			ms_cd(ms, ms->tokens->next->content);
+		else
+			ms_error_handler(ms, "cd: invalid args", 0);
+	}
+	else if (!ft_strncmp(ms->tokens->content, "env", 3))
+		ms_env(ms);
+	else if (!ft_strncmp(ms->tokens->content, "pwd", 3))
+		ms_pwd(ms);
+	else if (!ft_strncmp(ms->tokens->content, "unset", 5))
+		ms_unset(ms, ms->tokens);
+	else if (!ft_strncmp(ms->tokens->content, "exit", 4))
+		ms_exit(ms, ms->tokens);
+	else if (!ft_strncmp(ms->tokens->content, "echo", 4))
+		ms_echo(ms->tokens);
+	else if (!ft_strncmp(ms->tokens->content, "export", 6))
+		ms_export(ms, ms->tokens);
+}

--- a/src/main/loop.c
+++ b/src/main/loop.c
@@ -6,7 +6,7 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 18:26:23 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 14:30:52 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,15 +34,17 @@ char	*ms_check_empty_input(t_ms *ms, char *input)
 
 /*
 Main loop for Minishell.
-Calls for prompt build. 
+Calls for prompt build.
 Uses readline() to get input and adds it to history.
-Handles graceful exits and empty input. 
-For now, it just prints back the input.
+Catches CTRL+D input case (with null input check).
+Passes the input to the tokenizer and calls the executor.
 */
 void	ms_main_loop(t_ms *ms)
 {
 	while (42)
 	{
+		if (ms_get_set(0, 0))
+			ms_get_set(1, 0);
 		ms->prompt = ms_build_prompt(ms);
 		gc_add(ms->prompt, &ms->gc);
 		ms->input = readline(ms->prompt);
@@ -56,8 +58,7 @@ void	ms_main_loop(t_ms *ms)
 		if (!ms->input)
 			continue ;
 		add_history(ms->input);
-		ms_tokenizer(ms, ms->input);
+		ms_parser(ms, ms->input);
 		ms_executor(ms);
-		gc_add(ms->input, &ms->gc);
 	}
 }

--- a/src/main/prompt_utils.c
+++ b/src/main/prompt_utils.c
@@ -6,12 +6,51 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/28 12:53:16 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 08:40:36 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 09:05:01 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
+/*
+Stores a home reference in the ms minishell struct upon initialization.
+If home can't be built (init from non-existing dir), returns NULL. 
+*/
+char	*ms_make_home_ref(t_ms *ms, char **env)
+{
+	char	*cwd;
+	int		i;
+
+	i = 0;
+	while (env[i])
+	{
+		if (!ft_strncmp(env[i], "HOME", 4))
+			return (env[i] + 5);
+		i++;
+	}
+	cwd = NULL;
+	cwd = getcwd(cwd, PATH_MAX);
+	if (!cwd)
+		return (NULL);
+	gc_add(cwd, &ms->gc);
+	cwd = ft_strchr(cwd, '/');
+	gc_add(cwd, &ms->gc);
+	cwd = ft_substr(cwd, 0, ft_strchr_n(cwd, '/', 3) - cwd);
+	gc_add(cwd, &ms->gc);
+	return (cwd);
+}
+
+/*
+Main prompt building function.
+Calls a set of different functions that sequentially build a composite prompt.
+Minishell's implemented prompt contains:
+	-Minishell> signifier.
+	-Username and hostname
+	-CWD
+	-$ symbol to indicate end of prompt.
+Colors are implemented to differentiate it from bash, zsh and other shell calls.
+	(Minishell can be called from bash and viceversa; same with others)
+*/
 char	*ms_build_prompt(t_ms *ms)
 {
 	char	*user;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/10 16:29:23 by nponchon         ###   ########.fr       */
+/*   Updated: 2024/12/12 12:27:25 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,21 +42,11 @@ void	ms_remove_quotes(t_ms *ms)
 
 int	ms_parser(t_ms *ms, char *str)
 {
-	t_list	*tmp;
-
 	if (!ms_syntax_checker(ms, str))
 		return (FALSE);
 	if (!ms_tokenizer(ms, str))
 		return (FALSE);
 	ms_expand_variable(ms);
 	ms_remove_quotes(ms);
-	tmp = ms->tokens;
-	while (tmp)
-	{
-		printf("%s\n", (char *)tmp->content);
-		tmp = tmp->next;
-	}
-	ft_lstclear(&ms->tokens, free);
-	ms->tokens = NULL;
 	return (TRUE);
 }

--- a/src/parser/tokenizer.c
+++ b/src/parser/tokenizer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   tokenizer.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nponchon <nponchon@student.42.fr>          +#+  +:+       +#+        */
+/*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/09 15:32:36 by nponchon         ###   ########.fr       */
+/*   Updated: 2024/12/12 17:24:20 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -141,8 +141,6 @@ int	ms_tokenizer(t_ms *ms, char *str)
 			str++;
 		if (is_operator(str))
 			error = ms_handle_operator(ms, &str);
-		else if (is_quote(*str))
-			error = ms_extract_quote(ms, &str);
 		else
 			error = ms_extract_atom(ms, &str);
 	}

--- a/src/signals/signals.c
+++ b/src/signals/signals.c
@@ -6,25 +6,52 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 11:19:44 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/11/30 16:47:26 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/12 19:53:20 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
 /*
+This is a get-setter for the only global variable allowed in Minishell.
+The variable is used to indicate the reception of a signal and its number.
+To avoid splitting this into two functions (get and set), an action int is used.
+1 = set; 0 = get.
+*/
+int	ms_get_set(int action, int val)
+{
+	static int	var;
+
+	if (action == 1)
+		var = val;
+	return (var);
+}
+
+/*
 SIGINT handler.
-It re-prints the prompt in a new line and flushes stdout.
+Reprints the prompt in a new line, interrumpting a process.
 */
 
 void	ms_sigint_handler(void)
 {
-	ft_putstr_fd("\nshittyshell$ ", STDERR_FILENO);
-	fflush(stdout);
+	int	in_child;
+
+	in_child = ms_get_set(0, 0);
+	if (in_child)
+	{
+		ft_putstr_fd("\n", STDERR_FILENO);
+		return ;
+	}
+	ms_get_set(1, 0);
+	ft_putstr_fd("\n", STDERR_FILENO);
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
 }
 
 /*
 SIGTSTP handler.
+TODO: when jobs and processes are implemented, come back to build this.
 */
 void	ms_sigtstp_handler(void)
 {

--- a/src/utils/garbage_collector.c
+++ b/src/utils/garbage_collector.c
@@ -6,19 +6,16 @@
 /*   By: hmunoz-g <hmunoz-g@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/28 15:37:07 by hmunoz-g          #+#    #+#             */
-/*   Updated: 2024/12/09 18:35:02 by hmunoz-g         ###   ########.fr       */
+/*   Updated: 2024/12/11 15:11:40 by hmunoz-g         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
 /*
-This is the Garbage Collector hub. It is a simple tool that:
-	-Manages the GC list as a static t_list object
-	-keeps track of dynamically allocated resources
-	-Cleans up after itself with a function called before every exit.
+Helper function to print lists.
+Mainly used for debugging.
 */
-
 void	ms_print_list(t_list *list)
 {
 	while (list)
@@ -28,6 +25,11 @@ void	ms_print_list(t_list *list)
 	}
 }
 
+/*
+Main garbage collector function.
+Adds an entry to the gc list inside ms minishell struct.
+Before adding, checks if argument address is already store to avoid double frees.
+*/
 void	gc_add(void	*ptr, t_list **gc)
 {
 	t_list	*tmp;


### PR DESCRIPTION
Done a lot of things today, hope I don't forget anything.

The big thing is that our minishell can now execute both builtin and system commands. The system ones work wonderfully with the flags; the only builtin one that handles flags is echo (-n), which we'll have to see if the processing of the flags needs to be done in the parsing or the execution side.

The development of the executor has made it so minishell can't work with any command with an unset env. I didn't have time today to handle that, so tomorrow I'll tackle it.

Signal handling has been reworked and meshed with execution. Both CTRL+C (SIGINT) and CTRL+D appear to work correctly within parent and child processes, or at least they look the same as what bash does. 

There is at least one new function in libft, an ft_strjoin3 that joins 3 strings. I needed it and I did it. Call the cops.

This version of the code has the quickfix you sent me through slack so that $holi doesn't make minishell explode. I don't know if there is something more/different to do in this part of the code, but just have in mind that this push has that change implemented.

All my code is documented with comments (the execution part could use some more writing, but I'm SPENT). 

I think that's all, but who knows @_@ I need to go home and lay on the floor =_=